### PR TITLE
Add the gemname in option for gem bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Obviously ...
     $ gem gemspec                    # generates a [gem_name].gemspec using  Dir["{lib/**/*,[A-Z]*}"]
     $ gem gemspec --strategy gig     # uses s.files = `git ls-files app lib`.split("\n")
 
-    $ gem bootstrap
+    $ gem bootstrap                  # generates a [gem_name].gemspec using the current directory name
+    $ gem bootstrap your_gem         # creates an your_gem directory and generates your_gem.gemspec inside
     $ gem bootstrap --scaffold       # scaffolds lib/[gem_name]/version.rb, README, test/
     $ gem bootstrap --github         # inits a git repo, creates it on github and pushes it to github
                                      # (requires git config for github.user and github.token to be set)

--- a/lib/gem_release/helpers.rb
+++ b/lib/gem_release/helpers.rb
@@ -67,5 +67,15 @@ module GemRelease
     def gemspec_dirs
       Dir.glob('**/*.gemspec').map { |spec| File.dirname(spec) }
     end
+
+    def in_bootstrapped_dir
+      dir = Array(options[:args]).first rescue nil
+      if dir
+        Dir.mkdir dir
+        Dir.chdir(dir) { yield }
+      else
+        yield
+      end
+    end
   end
 end

--- a/lib/rubygems/commands/bootstrap_command.rb
+++ b/lib/rubygems/commands/bootstrap_command.rb
@@ -23,12 +23,17 @@ class Gem::Commands::BootstrapCommand < Gem::Command
     option :scaffold, '-s', 'Scaffold lib/[gem_name]/version.rb README test/'
     option :github,   '-h', 'Bootstrap a git repo, create on github and push'
     option :quiet,    '-q', 'Do not output status messages'
+
+    @arguments = "gemname - option name of the gem, will use the current directory if not specified"
+    @usage = "#{program_name} [gemname]"
   end
 
   def execute
-    write_scaffold if options[:scaffold]
-    write_gemspec  if options[:gemspec]
-    create_repo    if options[:github]
+    in_bootstrapped_dir do
+      write_scaffold if options[:scaffold]
+      write_gemspec  if options[:gemspec]
+      create_repo    if options[:github]
+    end
   end
 
   def write_gemspec

--- a/test/bootstrap_command_test.rb
+++ b/test/bootstrap_command_test.rb
@@ -52,4 +52,12 @@ class BootstrapCommandTest < Test::Unit::TestCase
 
     command.send(:create_repo)
   end
+
+  test "in_bootstrapped_dir" do
+    command = BootstrapCommand.new
+    command.options[:args] = "foo_baz"
+    command.in_bootstrapped_dir do
+      assert_equal "foo_baz", File.basename(Dir.pwd)
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I was also interested by adding an option to `gem release` to specify the name of the new gem (issue #6). So, here's the pull request.
