### PR TITLE
Abort if any sub-commands fail

### DIFF
--- a/lib/gem_release/helpers.rb
+++ b/lib/gem_release/helpers.rb
@@ -71,8 +71,7 @@ module GemRelease
     end
 
     def run_cmd(command)
-      send(command)
-      abort if $?.exitstatus != 0
+      abort unless send(command)
     end
   end
 end

--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -62,20 +62,21 @@ class Gem::Commands::BumpCommand < Gem::Command
         @new_version_number ||= version.new_number
         say "Bumping #{gem_name} from #{version.old_number} to version #{version.new_number}" unless quiet?
         version.bump!
-        `git add #{version.filename}` if options[:commit]
+        return system("git add #{version.filename}") if options[:commit]
       else
         say "Ignoring #{gem_name}. Version file #{version.filename} not found" unless quiet?
       end
+      true
     end
 
     def commit
       say "Creating commit" unless quiet?
-      `git commit -m "Bump to #{@new_version_number}"`
+      system("git commit -m \"Bump to #{@new_version_number}\"")
     end
 
     def push
       say "Pushing to the origin git repository" unless quiet?
-      `git push origin`
+      system('git push origin')
     end
 
     def release

--- a/lib/rubygems/commands/release_command.rb
+++ b/lib/rubygems/commands/release_command.rb
@@ -44,6 +44,7 @@ class Gem::Commands::ReleaseCommand < Gem::Command
 
     def build
       BuildCommand.new.invoke(gemspec_filename)
+      true
     end
 
     def push
@@ -54,11 +55,12 @@ class Gem::Commands::ReleaseCommand < Gem::Command
       args += "--quiet" if quiet?
 
       PushCommand.new.invoke(gem_filename, *args)
+      true
     end
 
     def remove
       say "Deleting left over gem file #{gem_filename}" unless quiet?
-      `rm #{gem_filename}`
+      system('rm #{gem_filename}')
     end
 
     def tag

--- a/lib/rubygems/commands/tag_command.rb
+++ b/lib/rubygems/commands/tag_command.rb
@@ -24,15 +24,15 @@ class Gem::Commands::TagCommand < Gem::Command
 
     def tag
       say "Creating git tag #{tag_name}" unless quiet?
-      `git tag -am 'tag #{tag_name}' #{tag_name}`
+      system("git tag -am 'tag #{tag_name}' #{tag_name}")
     end
 
     def push
       say "Pushing to the origin git repository" unless quiet?
-      `git push origin`
+      return false unless system('git push origin')
 
       say "Pushing --tags to the origin git repository" unless quiet?
-      `git push --tags origin`
+      system('git push --tags origin')
     end
 
     def tag_name

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -24,9 +24,9 @@ class BumpCommandTest < Test::Unit::TestCase
   test "gem bump" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
     command.invoke
   end
 
@@ -72,111 +72,111 @@ class BumpCommandTest < Test::Unit::TestCase
   test "gem bump --version 0.1.0" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.0"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.0"').returns(true)
     command.invoke('--version', '0.1.0')
   end
 
   test "`gem bump --version pre`, followed by `gem bump`" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2.pre1"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2.pre1"').returns(true)
     command.invoke('--version', 'pre')
 
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2.pre2"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2.pre2"').returns(true)
     command.invoke()
   end
 
   test "`gem bump --version 0.1.0.beta1`, followed by `gem bump`" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.0.beta1"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.0.beta1"').returns(true)
     command.invoke('--version', '0.1.0.beta1')
 
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.0.beta2"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.0.beta2"').returns(true)
     command.invoke()
   end
 
   test "`gem bump --version 0.1.0.1`, followed by `gem bump`" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.0.1"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.0.1"').returns(true)
     command.invoke('--version', '0.1.0.1')
 
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.0.2"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.0.2"').returns(true)
     command.invoke()
   end
 
   test "`gem bump --version 0.1.0.beta1`, followed by `gem bump --version patch`" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.0.beta1"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.0.beta1"').returns(true)
     command.invoke('--version', '0.1.0.beta1')
 
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.1.1"')
+    command.expects(:system).with('git commit -m "Bump to 0.1.1"').returns(true)
     command.invoke('--version', 'patch')
   end
 
   test "gem bump --push" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
-    command.expects(:`).with('git push origin')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
+    command.expects(:system).with('git push origin').returns(true)
     command.invoke('--push')
   end
 
   test "gem bump --tag" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
 
-    TagCommand.new.expects(:`).with("git tag -am 'tag v0.0.2' v0.0.2")
-    TagCommand.new.expects(:`).with('git push origin')
-    TagCommand.new.expects(:`).with('git push --tags origin')
+    TagCommand.new.expects(:system).with("git tag -am 'tag v0.0.2' v0.0.2").returns(true)
+    TagCommand.new.expects(:system).with('git push origin').returns(true)
+    TagCommand.new.expects(:system).with('git push --tags origin').returns(true)
     command.invoke('--tag')
   end
 
   test "gem bump --push --release" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
-    command.expects(:`).with('git push origin')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
+    command.expects(:system).with('git push origin').returns(true)
 
     count = gemspec_dirs.size
-    ReleaseCommand.any_instance.expects(:build).times(count)
-    ReleaseCommand.any_instance.expects(:push).times(count)
-    ReleaseCommand.any_instance.expects(:remove).times(count)
+    ReleaseCommand.any_instance.expects(:build).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:push).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:remove).times(count).returns(true)
 
     command.invoke('--push', '--release')
   end
@@ -184,17 +184,17 @@ class BumpCommandTest < Test::Unit::TestCase
   test "gem bump --tag --release" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
 
     count = gemspec_dirs.size
-    ReleaseCommand.any_instance.expects(:build).times(count)
-    ReleaseCommand.any_instance.expects(:push).times(count)
-    ReleaseCommand.any_instance.expects(:remove).times(count)
+    ReleaseCommand.any_instance.expects(:build).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:push).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:remove).times(count).returns(true)
 
-    TagCommand.any_instance.expects(:tag)
-    TagCommand.any_instance.expects(:push)
+    TagCommand.any_instance.expects(:tag).returns(true)
+    TagCommand.any_instance.expects(:push).returns(true)
 
     command.invoke('--tag', '--release')
   end
@@ -202,17 +202,17 @@ class BumpCommandTest < Test::Unit::TestCase
   test "gem bump --release --key" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
 
     count = gemspec_dirs.size
-    ReleaseCommand.any_instance.expects(:build).times(count)
-    ReleaseCommand.any_instance.expects(:remove).times(count)
+    ReleaseCommand.any_instance.expects(:build).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:remove).times(count).returns(true)
 
     keyname = "keyname"
     in_gemspec_dirs do
-      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--key" && a2 == keyname }
+      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--key" && a2 == keyname }.returns(true)
     end
 
     command.invoke('--release', '--key', keyname)
@@ -221,17 +221,17 @@ class BumpCommandTest < Test::Unit::TestCase
   test "gem bump --release --host" do
     command = BumpCommand.new
     in_gemspec_dirs do
-      command.expects(:`).with("git add #{version.send(:filename)}")
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
     end
-    command.expects(:`).with('git commit -m "Bump to 0.0.2"')
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
 
     count = gemspec_dirs.size
-    ReleaseCommand.any_instance.expects(:build).times(count)
-    ReleaseCommand.any_instance.expects(:remove).times(count)
+    ReleaseCommand.any_instance.expects(:build).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:remove).times(count).returns(true)
 
     hostname = "http://hostname.example.com"
     in_gemspec_dirs do
-      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--host" && a2 == hostname }
+      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--host" && a2 == hostname }.returns(true)
     end
 
     command.invoke('--release', '--host', hostname)

--- a/test/release_command_test.rb
+++ b/test/release_command_test.rb
@@ -38,14 +38,14 @@ class ReleaseCommandTest < Test::Unit::TestCase
   end
 
   test "tag executes TagCommand if --tag option was given" do
-    TagCommand.new.expects(:execute)
-    ReleaseCommand.new.invoke('--tag')
+    TagCommand.new.expects(:execute).returns(true)
+    assert_equal true, ReleaseCommand.new.invoke('--tag')
   end
 
   test "passes --key args to the push command" do
     key_name = "example"
     in_gemspec_dirs do
-      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--key" && a2 == key_name }
+      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--key" && a2 == key_name }.returns(true)
     end
     ReleaseCommand.new.invoke('--key', key_name)
   end
@@ -53,7 +53,7 @@ class ReleaseCommandTest < Test::Unit::TestCase
   test "passes --host args to the push command" do
     host_name = "http://hostname.example.com"
     in_gemspec_dirs do
-      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--host" && a2 == host_name }
+      PushCommand.any_instance.expects(:invoke).with() { |_, a1, a2| a1 ==  "--host" && a2 == host_name }.returns(true)
     end
     ReleaseCommand.new.invoke('--host', host_name)
   end

--- a/test/tag_command_test.rb
+++ b/test/tag_command_test.rb
@@ -11,9 +11,9 @@ class TagCommandTest < Test::Unit::TestCase
   test "tag_command" do
     command = TagCommand.new
     command.stubs(:gem_version).returns('1.0.0')
-    command.expects(:`).with("git tag -am 'tag v1.0.0' v1.0.0")
-    command.expects(:`).with("git push origin")
-    command.expects(:`).with("git push --tags origin")
+    command.expects(:system).with("git tag -am 'tag v1.0.0' v1.0.0").returns(:true)
+    command.expects(:system).with("git push origin").returns(:true)
+    command.expects(:system).with("git push --tags origin").returns(:true)
     command.execute
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,7 +58,7 @@ class Test::Unit::TestCase
 
   def stub_command(command_class, *methods)
     command = command_class.new
-    methods.each { |method| command.stubs(method) }
+    methods.each { |method| command.stubs(method).returns(true) }
     command_class.stubs(:new).returns(command)
   end
 


### PR DESCRIPTION
If any sub-command like bumping fails the whole program will now exit with a non-zero code instead of proceeding and doing bad stuff like building and releasing the Gem after not being able to push to Git remote.
