### PR TITLE
Using double quotes to support Windows command prompt

### DIFF
--- a/lib/core_ext/kernel/silence.rb
+++ b/lib/core_ext/kernel/silence.rb
@@ -6,7 +6,7 @@ module Kernel
   def silence_stream(*streams)
     on_hold = streams.collect{ |stream| stream.dup }
     streams.each do |stream|
-      stream.reopen(RUBY_PLATFORM =~ /mswin/ ? 'NUL:' : '/dev/null')
+      stream.reopen(RUBY_PLATFORM =~ /mswin|mingw/ ? 'NUL:' : '/dev/null')
       stream.sync = true
     end
     yield

--- a/lib/rubygems/commands/bootstrap_command.rb
+++ b/lib/rubygems/commands/bootstrap_command.rb
@@ -81,7 +81,7 @@ class Gem::Commands::BootstrapCommand < Gem::Command
     `git add .`
 
     say 'Creating initial commit'
-    `git commit -m 'initial commit'`
+    `git commit -m "initial commit"`
 
     say "Adding remote origin git@github.com:#{github_user}/#{gem_name}.git"
     `git remote add origin git@github.com:#{github_user}/#{gem_name}.git`

--- a/lib/rubygems/commands/tag_command.rb
+++ b/lib/rubygems/commands/tag_command.rb
@@ -26,7 +26,7 @@ class Gem::Commands::TagCommand < Gem::Command
 
     def tag
       say "Creating git tag #{tag_name}" unless quiet?
-      system("git tag -am 'tag #{tag_name}' #{tag_name}")
+      system("git tag -am \"tag #{tag_name}\" #{tag_name}")
     end
 
     def push

--- a/test/bootstrap_command_test.rb
+++ b/test/bootstrap_command_test.rb
@@ -45,7 +45,7 @@ class BootstrapCommandTest < Test::Unit::TestCase
     command.stubs(:github_token).returns('token')
 
     command.expects(:`).with("git add .")
-    command.expects(:`).with("git commit -m 'initial commit'")
+    command.expects(:`).with("git commit -m \"initial commit\"")
     command.expects(:`).with("git remote add origin git@github.com:svenfuchs/foo-bar.git")
     command.expects(:`).with("git push origin master")
     command.expects(:`).with do |cmd|

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -160,7 +160,7 @@ class BumpCommandTest < Test::Unit::TestCase
     command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
     command.expects(:system).with('git push origin').returns(true)
 
-    TagCommand.new.expects(:system).with("git tag -am 'tag v0.0.2' v0.0.2").returns(true)
+    TagCommand.new.expects(:system).with("git tag -am \"tag v0.0.2\" v0.0.2").returns(true)
     TagCommand.new.expects(:system).with('git push --tags origin').returns(true)
     command.invoke('--tag')
   end

--- a/test/tag_command_test.rb
+++ b/test/tag_command_test.rb
@@ -11,7 +11,7 @@ class TagCommandTest < Test::Unit::TestCase
   test "tag_command" do
     command = TagCommand.new
     command.stubs(:gem_version).returns('1.0.0')
-    command.expects(:system).with("git tag -am 'tag v1.0.0' v1.0.0").returns(:true)
+    command.expects(:system).with("git tag -am \"tag v1.0.0\" v1.0.0").returns(:true)
     command.expects(:system).with("git push origin").returns(:true)
     command.expects(:system).with("git push --tags origin").returns(:true)
     command.execute
@@ -21,7 +21,7 @@ class TagCommandTest < Test::Unit::TestCase
     command = TagCommand.new
     command.options[:push_tags_only] = true
     command.stubs(:gem_version).returns('1.0.0')
-    command.expects(:system).with("git tag -am 'tag v1.0.0' v1.0.0").returns(:true)
+    command.expects(:system).with("git tag -am \"tag v1.0.0\" v1.0.0").returns(:true)
     command.expects(:system).with("git push --tags origin").returns(:true)
     command.execute
   end


### PR DESCRIPTION
I'm developing gems in (and for) Windows and the Command Prompt cannot handle single quotes (e.g. `git tag -am 'v1.0.0' v1.0.0` fails with `fatal: Failed to resolve 'v1.0.0' as a valid ref.`). I could use Git Bash that comes with msysGit, but it's also an easy fix to support Command Prompt with this change. Double quotes are supported on all platforms.

Here's a relevant discussion from 2009: https://groups.google.com/forum/#!topic/msysgit/qzKNBrjYUUM/discussion
