### PR TITLE
Add release argument to version option of bump

### DIFF
--- a/lib/gem_release/version_file.rb
+++ b/lib/gem_release/version_file.rb
@@ -14,6 +14,8 @@ module GemRelease
       @target = options[:target]
       if @target == nil || @target == ''
         @target = is_prerelease_version_number?(old_number) ? :pre : :patch
+      elsif @target.to_sym == :release
+        @target = :patch if(!is_prerelease_version_number?(old_number))
       end
     end
 
@@ -32,7 +34,7 @@ module GemRelease
           end
         elsif is_prerelease_version_number?(old_number)
           old_number.sub(PRERELEASE_NUMBER_PATTERN) do
-            prerelease($1, $2, $3, $4, $5)
+            (target.to_sym == :release) ? release($1, $2, $3) : prerelease($1, $2, $3, $4, $5)
           end
         else
           old_number.sub(NUMBER_PATTERN) do
@@ -73,6 +75,10 @@ module GemRelease
 
       def patch(major, minor, patch)
         "#{major}.#{minor}.#{patch.to_i + 1}"
+      end
+
+      def release(major, minor, patch)
+        "#{major}.#{minor}.#{patch}"
       end
 
       def prerelease(major, minor, patch, prereleasePrefix, prereleaseNumber)

--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -22,7 +22,7 @@ class Gem::Commands::BumpCommand < Gem::Command
   def initialize(options = {})
     super 'bump', 'Bump the gem version', DEFAULTS.merge(options)
 
-    option :version, '-v', 'Target version: next [major|minor|patch|pre] or a given version number [x.x.x]'
+    option :version, '-v', 'Target version: next [major|minor|patch|pre|release] or a given version number [x.x.x]'
     option :commit,  '-c', 'Perform a commit after incrementing gem version'
     option :push,    '-p', 'Push to the origin git repository'
     option :tag,     '-t', 'Create a git tag and push --tags to origin'

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -110,6 +110,38 @@ class BumpCommandTest < Test::Unit::TestCase
     command.invoke()
   end
 
+  test "`gem bump --version 0.1.0.beta1`, followed by `gem bump --version release`" do
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.1.0.beta1"').returns(true)
+    command.invoke('--version', '0.1.0.beta1')
+
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.1.0"').returns(true)
+    command.invoke('--version', 'release')
+  end
+
+  test "`gem bump --version 0.1.0`, followed by `gem bump --version release`" do
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.1.0"').returns(true)
+    command.invoke('--version', '0.1.0')
+
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.1.1"').returns(true)
+    command.invoke('--version', 'release')
+  end
+
   test "`gem bump --version 0.1.0.1`, followed by `gem bump`" do
     command = BumpCommand.new
     in_gemspec_dirs do


### PR DESCRIPTION
This pull request adds the 'release' argument to the --version option on the bump command. If the current version is a prerelease version, this argument will strip the prerelease segments of the version string. If the current version is not a prerelease, the command `gem bump --version release` is equivalent to `gem bump --version patch`

For example, if version = 0.1.0.pre, the command `gem bump --version release` will result in version = 0.1.0
