### PR TITLE
fix incorrect pre versions incrementing

### DIFF
--- a/lib/gem_release/version_file.rb
+++ b/lib/gem_release/version_file.rb
@@ -6,7 +6,7 @@ module GemRelease
 
     VERSION_PATTERN = /(VERSION\s*=\s*(?:"|'))((?:(?!"|').)*)("|')/
     NUMBER_PATTERN  = /(\d+)\.(\d+)\.(\d+)(.*)/
-    PRERELEASE_NUMBER_PATTERN  = /(\d+)\.(\d+)\.(\d+)\.(.*)(\d+)/
+    PRERELEASE_NUMBER_PATTERN  = /(\d+)\.(\d+)\.(\d+)\.(\D+|.*)(\d+)/
 
     attr_reader :target
 

--- a/test/version_file_test.rb
+++ b/test/version_file_test.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../test_helper', __FILE__)
+
+class VersionFileTest < Test::Unit::TestCase
+  include GemRelease
+
+  test "correct new version for pre version" do
+    version_file = VersionFile.new(target: "pre")
+    version_file.stubs(:old_number).returns("1.0.1.pre19")
+
+    assert_equal "1.0.1.pre20", version_file.new_number
+  end
+end


### PR DESCRIPTION
I found one strange behaviour of `new_number` method.

Example:

You have a gem with the version "1.0.1.pre19" and you would like to release another pre version, and I'm expecting that it would be "1.0.1.pre20". However, VersionFile does return me "1.0.1.pre110".

``` ruby
module MyEngine
  VERSION = "1.0.1.pre19"
end
```

Irb output:

```
1.9.3-p484 :001 > require 'gem_release'
 => true
1.9.3-p484 :002 > GemRelease::VersionFile.new(target: :pre).new_number
 => "1.0.1.pre110"
```

This happens because of incorrect version parsing.

I added a fix and a test case to reproduce it and ensure that it's being fixed.

Would be happy to hear any feedback.
