### PR TITLE
Escape `version.filename` in case of spaces in path

### DIFF
--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -1,6 +1,7 @@
 require 'gem_release'
 require 'rubygems/commands/tag_command'
 require 'rubygems/commands/release_command'
+require 'shellwords'
 
 class Gem::Commands::BumpCommand < Gem::Command
   include GemRelease, Gem::Commands
@@ -65,11 +66,15 @@ class Gem::Commands::BumpCommand < Gem::Command
         @new_version_number ||= version.new_number
         say "Bumping #{gem_name} from #{version.old_number} to version #{version.new_number}" unless quiet?
         version.bump!
-        return system("git add #{version.filename}") if options[:commit]
+        return system("git add #{escape(version.filename)}") if options[:commit]
       else
         say "Ignoring #{gem_name}. Version file #{version.filename} not found" unless quiet?
       end
       true
+    end
+
+    def escape(string)
+      Shellwords.escape(string)
     end
 
     def commit

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -57,6 +57,20 @@ class BumpCommandTest < Test::Unit::TestCase
     assert version_1.include?('0.0.2')
   end
 
+  test "gem bump with with space in path" do
+    path_with_space = "lib/foo bar"
+    expected = 'lib/foo\\ bar'
+    path = BumpCommand.new.send(:escape, path_with_space)
+    assert_equal expected, path
+  end
+
+  test "gem bump without space in path" do
+    path_without_space = "lib/foo_bar"
+    expected = 'lib/foo_bar'
+    path = BumpCommand.new.send(:escape, path_without_space)
+    assert_equal expected, path
+  end
+
   test "gem bump with version in lib/foo_bar/" do
     # move version.rb to the alternate dir: /lib/foo_bar
     FileUtils.mkdir('lib/foo_bar')


### PR DESCRIPTION
Fixes Issue [#33] where the path contains a space.  Using `shellwords` module
provides a simple way to escape path strings before executing git commands via
`Kernel#system`.
