### PR TITLE
specific git remote with default to origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `tag` command
 
  * executes `git tag -am "tag [tag_name]" [tag_name]`, with `tag_name` being the version number as specified in your .gemspec preceded  by `v` (e.g. `v0.0.1`)
  * executes `git push origin`
- * executes `git push --tags origin`
+ * executes `git push origin [tag_name]`
 
 The `release` command
 

--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -29,7 +29,7 @@ class Gem::Commands::BumpCommand < Gem::Command
     option :commit,      '-c', 'Perform a commit after incrementing gem version'
     option :push,        '-p', 'Push to the git destination'
     option :destination, '-d', 'destination git repository'
-    option :tag,         '-t', 'Create a git tag and push --tags to git destination'
+    option :tag,         '-t', 'Create a git tag and push it to the git destination'
     option :release,     '-r', 'Build gem from a gemspec and push to rubygems.org'
     option :key,         '-k', 'When releasing: use the given API key from ~/.gem/credentials'
     option :host,        '-h', 'When releasing: push to a gemcutter-compatible host other than rubygems.org'

--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -10,28 +10,30 @@ class Gem::Commands::BumpCommand < Gem::Command
   attr_reader :arguments, :usage, :name
 
   DEFAULTS = {
-    :version  => '',
-    :commit   => true,
-    :push     => false,
-    :tag      => false,
-    :release  => false,
-    :key      => '',
-    :host     => '',
-    :quiet    => false
+    :version => '',
+    :commit  => true,
+    :push    => false,
+    :tag     => false,
+    :release => false,
+    :key     => '',
+    :host    => '',
+    :quiet   => false,
+    :destination  => "origin",
   }
 
   def initialize(options = {})
     @name = 'bump'
     super @name, 'Bump the gem version', default_options_with(options)
 
-    option :version, '-v', 'Target version: next [major|minor|patch|pre|release] or a given version number [x.x.x]'
-    option :commit,  '-c', 'Perform a commit after incrementing gem version'
-    option :push,    '-p', 'Push to the origin git repository'
-    option :tag,     '-t', 'Create a git tag and push --tags to origin'
-    option :release, '-r', 'Build gem from a gemspec and push to rubygems.org'
-    option :key,     '-k', 'When releasing: use the given API key from ~/.gem/credentials'
-    option :host,    '-h', 'When releasing: push to a gemcutter-compatible host other than rubygems.org'
-    option :quiet,   '-q', 'Do not output status messages'
+    option :version,     '-v', 'Target version: next [major|minor|patch|pre|release] or a given version number [x.x.x]'
+    option :commit,      '-c', 'Perform a commit after incrementing gem version'
+    option :push,        '-p', 'Push to the git destination'
+    option :destination, '-d', 'destination git repository'
+    option :tag,         '-t', 'Create a git tag and push --tags to git destination'
+    option :release,     '-r', 'Build gem from a gemspec and push to rubygems.org'
+    option :key,         '-k', 'When releasing: use the given API key from ~/.gem/credentials'
+    option :host,        '-h', 'When releasing: push to a gemcutter-compatible host other than rubygems.org'
+    option :quiet,       '-q', 'Do not output status messages'
   end
 
   def execute
@@ -83,8 +85,9 @@ class Gem::Commands::BumpCommand < Gem::Command
     end
 
     def push
-      say "Pushing to the origin git repository" unless quiet?
-      system('git push origin')
+      destination = options[:destination]
+      say "Pushing to the #{destination} git repository" unless quiet?
+      system("git push #{destination}")
     end
 
     def release

--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -106,6 +106,7 @@ class Gem::Commands::BumpCommand < Gem::Command
       cmd.options[:quiet] = options[:quiet]
       cmd.options[:quiet_success] = true
       cmd.options[:push_tags_only] = true
+      cmd.options[:destination] = options[:destination]
       cmd.execute
       true
     end

--- a/lib/rubygems/commands/release_command.rb
+++ b/lib/rubygems/commands/release_command.rb
@@ -20,7 +20,7 @@ class Gem::Commands::ReleaseCommand < Gem::Command
     @name = 'release'
     super @name, 'Build gem from a gemspec and push to rubygems.org', default_options_with(options)
 
-    option :tag,         '-t', 'Create a git tag and push --tags to destination'
+    option :tag,         '-t', 'Create a git tag and push it to the destination'
     option :destination, '-d', 'Destination git repository'
     option :quiet,       '-q', 'Do not output status messages'
     option :key,         '-k', 'Use the given API key from ~/.gem/credentials'

--- a/lib/rubygems/commands/release_command.rb
+++ b/lib/rubygems/commands/release_command.rb
@@ -7,10 +7,11 @@ class Gem::Commands::ReleaseCommand < Gem::Command
   include Helpers, CommandOptions
 
   DEFAULTS = {
-    :tag   => false,
-    :quiet => false,
-    :key   => '',
-    :host  => ''
+    :tag         => false,
+    :quiet       => false,
+    :key         => '',
+    :host        => '',
+    :destination => "origin",
   }
 
   attr_reader :arguments, :usage, :name
@@ -19,10 +20,11 @@ class Gem::Commands::ReleaseCommand < Gem::Command
     @name = 'release'
     super @name, 'Build gem from a gemspec and push to rubygems.org', default_options_with(options)
 
-    option :tag,   '-t', 'Create a git tag and push --tags to origin'
-    option :quiet, '-q', 'Do not output status messages'
-    option :key,   '-k', 'Use the given API key from ~/.gem/credentials'
-    option :host,  '-h', 'Push to a gemcutter-compatible host other than rubygems.org'
+    option :tag,         '-t', 'Create a git tag and push --tags to destination'
+    option :destination, '-d', 'Destination git repository'
+    option :quiet,       '-q', 'Do not output status messages'
+    option :key,         '-k', 'Use the given API key from ~/.gem/credentials'
+    option :host,        '-h', 'Push to a gemcutter-compatible host other than rubygems.org'
 
     @arguments = "gemspec - optional gemspec file name, will use the first *.gemspec if not specified"
     @usage = "#{program_name} [gemspec]"

--- a/lib/rubygems/commands/tag_command.rb
+++ b/lib/rubygems/commands/tag_command.rb
@@ -11,7 +11,7 @@ class Gem::Commands::TagCommand < Gem::Command
 
   def initialize(options = {})
     @name = 'tag'
-    super @name, 'Create a git tag and push --tags to destination', default_options_with(options)
+    super @name, 'Create a git tag and push it to the destination', default_options_with(options)
 
     option :quiet,       '-q', 'Do not output status messages'
     option :destination, '-d', 'Git destination'
@@ -38,8 +38,8 @@ class Gem::Commands::TagCommand < Gem::Command
         return false unless system("git push #{options[:destination]}")
       end
 
-      say "Pushing --tags to the #{options[:destination]} git repository" unless quiet?
-      system("git push --tags #{options[:destination]}")
+      say "Pushing #{tag_name} to the #{options[:destination]} repository" unless quiet?
+      system("git push #{options[:destination]} #{tag_name}")
     end
 
     def tag_name

--- a/lib/rubygems/commands/tag_command.rb
+++ b/lib/rubygems/commands/tag_command.rb
@@ -3,16 +3,18 @@ class Gem::Commands::TagCommand < Gem::Command
   include Helpers, CommandOptions
 
   DEFAULTS = {
-    :quiet => false
+    :quiet       => false,
+    :destination => "origin"
   }
 
   attr_reader :arguments, :usage, :name
 
   def initialize(options = {})
     @name = 'tag'
-    super @name, 'Create a git tag and push --tags to origin', default_options_with(options)
+    super @name, 'Create a git tag and push --tags to destination', default_options_with(options)
 
-    option :quiet, '-q', 'Do not output status messages'
+    option :quiet,       '-q', 'Do not output status messages'
+    option :destination, '-d', 'Git destination'
   end
 
   def execute
@@ -33,11 +35,11 @@ class Gem::Commands::TagCommand < Gem::Command
     def push
       unless options[:push_tags_only]
         say "Pushing to the origin git repository" unless quiet?
-        return false unless system('git push origin')
+        return false unless system("git push #{options[:destination]}")
       end
 
-      say "Pushing --tags to the origin git repository" unless quiet?
-      system('git push --tags origin')
+      say "Pushing --tags to the #{options[:destination]} git repository" unless quiet?
+      system("git push --tags #{options[:destination]}")
     end
 
     def tag_name

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -217,7 +217,7 @@ class BumpCommandTest < Test::Unit::TestCase
     command.expects(:system).with('git push origin').returns(true)
 
     TagCommand.new.expects(:system).with("git tag -am \"tag v0.0.2\" v0.0.2").returns(true)
-    TagCommand.new.expects(:system).with('git push --tags origin').returns(true)
+    TagCommand.new.expects(:system).with('git push origin v0.0.2').returns(true)
     command.invoke('--tag')
   end
 
@@ -230,7 +230,7 @@ class BumpCommandTest < Test::Unit::TestCase
     command.expects(:system).with('git push fork').returns(true)
 
     TagCommand.new.expects(:system).with("git tag -am \"tag v0.0.2\" v0.0.2").returns(true)
-    TagCommand.new.expects(:system).with('git push --tags fork').returns(true)
+    TagCommand.new.expects(:system).with('git push fork v0.0.2').returns(true)
     command.invoke('--tag', '-d', 'fork')
   end
 

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -198,6 +198,16 @@ class BumpCommandTest < Test::Unit::TestCase
     command.invoke('--push')
   end
 
+  test "gem bump --push -d fork" do
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
+    command.expects(:system).with('git push fork').returns(true)
+    command.invoke('--push', '-d', 'fork')
+  end
+
   test "gem bump --tag" do
     command = BumpCommand.new
     in_gemspec_dirs do
@@ -244,6 +254,25 @@ class BumpCommandTest < Test::Unit::TestCase
     TagCommand.any_instance.expects(:push).returns(true)
 
     command.invoke('--tag', '--release')
+  end
+
+  test "gem bump --tag --release --destination fork" do
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
+    command.expects(:system).with('git push fork').returns(true)
+
+    count = gemspec_dirs.size
+    ReleaseCommand.any_instance.expects(:build).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:push).times(count).returns(true)
+    ReleaseCommand.any_instance.expects(:cleanup).times(count).returns(true)
+
+    TagCommand.any_instance.expects(:tag).returns(true)
+    TagCommand.any_instance.expects(:push).returns(true)
+
+    command.invoke('--tag', '--release', '--destination', 'fork')
   end
 
   test "gem bump --release --key" do

--- a/test/bump_command_test.rb
+++ b/test/bump_command_test.rb
@@ -221,6 +221,19 @@ class BumpCommandTest < Test::Unit::TestCase
     command.invoke('--tag')
   end
 
+  test "gem bump --tag -d fork" do
+    command = BumpCommand.new
+    in_gemspec_dirs do
+      command.expects(:system).with("git add #{version.send(:filename)}").returns(true)
+    end
+    command.expects(:system).with('git commit -m "Bump to 0.0.2"').returns(true)
+    command.expects(:system).with('git push fork').returns(true)
+
+    TagCommand.new.expects(:system).with("git tag -am \"tag v0.0.2\" v0.0.2").returns(true)
+    TagCommand.new.expects(:system).with('git push --tags fork').returns(true)
+    command.invoke('--tag', '-d', 'fork')
+  end
+
   test "gem bump --push --release" do
     command = BumpCommand.new
     in_gemspec_dirs do

--- a/test/tag_command_test.rb
+++ b/test/tag_command_test.rb
@@ -25,4 +25,14 @@ class TagCommandTest < Test::Unit::TestCase
     command.expects(:system).with("git push --tags origin").returns(:true)
     command.execute
   end
+
+  test "tag_command pushes to a specific git remote" do
+    command = TagCommand.new
+    command.options[:push_tags_only] = true
+    command.options[:destination] = "fork"
+    command.stubs(:gem_version).returns('1.0.0')
+    command.expects(:system).with("git tag -am \"tag v1.0.0\" v1.0.0").returns(:true)
+    command.expects(:system).with("git push --tags fork").returns(:true)
+    command.execute
+  end
 end

--- a/test/tag_command_test.rb
+++ b/test/tag_command_test.rb
@@ -13,7 +13,7 @@ class TagCommandTest < Test::Unit::TestCase
     command.stubs(:gem_version).returns('1.0.0')
     command.expects(:system).with("git tag -am \"tag v1.0.0\" v1.0.0").returns(:true)
     command.expects(:system).with("git push origin").returns(:true)
-    command.expects(:system).with("git push --tags origin").returns(:true)
+    command.expects(:system).with("git push origin v1.0.0").returns(:true)
     command.execute
   end
 
@@ -22,7 +22,7 @@ class TagCommandTest < Test::Unit::TestCase
     command.options[:push_tags_only] = true
     command.stubs(:gem_version).returns('1.0.0')
     command.expects(:system).with("git tag -am \"tag v1.0.0\" v1.0.0").returns(:true)
-    command.expects(:system).with("git push --tags origin").returns(:true)
+    command.expects(:system).with("git push origin v1.0.0").returns(:true)
     command.execute
   end
 
@@ -32,7 +32,7 @@ class TagCommandTest < Test::Unit::TestCase
     command.options[:destination] = "fork"
     command.stubs(:gem_version).returns('1.0.0')
     command.expects(:system).with("git tag -am \"tag v1.0.0\" v1.0.0").returns(:true)
-    command.expects(:system).with("git push --tags fork").returns(:true)
+    command.expects(:system).with("git push fork v1.0.0").returns(:true)
     command.execute
   end
 end


### PR DESCRIPTION
the git remote I wish to push to isn't allows `origin`.  Allow specifying a different remote but default to origin.