### PR TITLE
R.I.P. RubyForge

### DIFF
--- a/gem-release.gemspec
+++ b/gem-release.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files {app,lib}`.split("\n")
   s.require_path = 'lib'
   s.platform     = Gem::Platform::RUBY
-  s.rubyforge_project = '[none]'
 
   s.add_development_dependency 'test_declarative', '>=0.0.2'
   s.add_development_dependency 'mocha', '>=0.14'

--- a/lib/gem_release/templates/gemspec
+++ b/lib/gem_release/templates/gemspec
@@ -15,5 +15,4 @@ Gem::Specification.new do |s|
   s.files         = <%= files %>
   s.platform      = Gem::Platform::RUBY
   s.require_paths = ['lib']
-  s.rubyforge_project = '[none]'
 end


### PR DESCRIPTION
The inclusion of a line referencing the long defunct RubyForge is probably no longer necessary.
