### PR TITLE
Include test-unit gem, avoids conflict with MiniTest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source "https://rubygems.org"
 gemspec
+
+group :development do
+  gem 'test-unit'
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'rubygems_plugin'
+require 'bundler/setup'
 
 require 'test/unit'
 require 'fileutils'


### PR DESCRIPTION
Unless the [test-unit gem](https://rubygems.org/gems/test-unit) is included, you'll get a slew of errors in newer versions of Ruby that come bundled with MiniTest. They typically look like this:

    Warning: you should require 'minitest/autorun' instead.
    Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
    From:
      /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/2.1.0/test/unit.rb:1:in `<top (required)>'
      /Users/tadman/git/gem-release/test/test_helper.rb:4:in `<top (required)>'
      /Users/tadman/git/gem-release/test/bootstrap_command_test.rb:1:in `<top (required)>'
      /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
      /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:9:in `each'
      /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:9:in `block in <main>'
      /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:4:in `select'
      /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:4:in `<main>'
    MiniTest::Unit::TestCase is now Minitest::Test. From /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/2.1.0/test/unit/testcase.rb:8:in `<module:Unit>'
    /Users/tadman/.rbenv/versions/2.1.5/lib/ruby/2.1.0/test/unit.rb:676:in `<class:Runner>': undefined method `_run_suite' for class `Test::Unit::Runner' (NameError)

This is fixed by deliberately using the `test-unit` gem.

The suite wouldn't run at all until I did this, `rake` would abort with that error. When included it ran flawlessly.
