### PR TITLE
fix --file opt switch

### DIFF
--- a/lib/gem/release/cmds/bump.rb
+++ b/lib/gem/release/cmds/bump.rb
@@ -105,7 +105,7 @@ module Gem
           opts[:recurse] = value
         end
 
-        opt '--file', descr(:file) do |value|
+        opt '--file FILE', descr(:file) do |value|
           opts[:file] = value
         end
 


### PR DESCRIPTION
Define an argument FILE that signals to make_switch that the value will
be a String.  Without this, `--file` is always parsed as a boolean.