### PR TITLE
Version number complying to SemVer format

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ major       # Bump to the next major level (e.g. 0.0.1 to 1.0.0)
 minor       # Bump to the next minor level (e.g. 0.0.1 to 0.1.0)
 patch       # Bump to the next patch level (e.g. 0.0.1 to 0.0.2)
 pre|rc|etc  # Bump to the next pre-release level (e.g. 0.0.1 to
-            #   0.1.0.pre.1, 1.0.0.pre.1 to 1.0.0.pre.2)
+            #   0.1.0-pre.1, 1.0.0-pre.1 to 1.0.0-pre.2)
 ```
 
 When searching for the version file for a gem named `gem-name`: the

--- a/lib/gem/release/version/number.rb
+++ b/lib/gem/release/version/number.rb
@@ -2,14 +2,15 @@ module Gem
   module Release
     module Version
       class Number < Struct.new(:number, :target)
-        NUMBER = /^(\d+)\.(\d+).(\d+).?(\w+)?.?(\d+)?$/
+        NUMBER = /^(\d+)\.(\d+).(\d+)-?(\w+)?.?(\d+)?$/
 
         STAGES = %i(alpha beta pre rc)
 
         def bump
           return target if specific?
           validate_stage
-          [major, minor, patch, stage, num].compact.join('.')
+          [major, minor, patch].compact.join('.') +
+            (stage ? '-' + [stage, num].join('.') : '')
         end
 
         private

--- a/spec/gem/release/cmds/bump_spec.rb
+++ b/spec/gem/release/cmds/bump_spec.rb
@@ -84,7 +84,7 @@ describe Gem::Release::Cmds::Bump do
 
     describe 'pre' do
       let(:opts) { { version: :pre } }
-      it { should have_version 'foo/bar', '1.1.0.pre.1' }
+      it { should have_version 'foo/bar', '1.1.0-pre.1' }
     end
   end
 

--- a/spec/gem/release/version/number_spec.rb
+++ b/spec/gem/release/version/number_spec.rb
@@ -31,12 +31,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.1.0.pre.1' }
+      it { should eq '1.1.0-pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.1.0.rc.1' }
+      it { should eq '1.1.0-rc.1' }
     end
   end
 
@@ -65,12 +65,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.2.0.pre.1' }
+      it { should eq '1.2.0-pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.2.0.rc.1' }
+      it { should eq '1.2.0-rc.1' }
     end
   end
 
@@ -99,17 +99,17 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.2.0.pre.1' }
+      it { should eq '1.2.0-pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.2.0.rc.1' }
+      it { should eq '1.2.0-rc.1' }
     end
   end
 
   describe 'given 1.1.1.pre.1' do
-    let(:number) { '1.1.1.pre.1' }
+    let(:number) { '1.1.1-pre.1' }
 
     describe 'given target: :major' do
       let(:target) { :major }
@@ -128,22 +128,22 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.1.1.pre.2' }
+      it { should eq '1.1.1-pre.2' }
     end
 
     describe 'given target: nil (defaults to :pre)' do
       let(:target) { nil }
-      it { should eq '1.1.1.pre.2' }
+      it { should eq '1.1.1-pre.2' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.1.1.rc.1' }
+      it { should eq '1.1.1-rc.1' }
     end
   end
 
   describe 'given 1.1.1.rc.1' do
-    let(:number) { '1.1.1.rc.1' }
+    let(:number) { '1.1.1-rc.1' }
 
     describe 'given target: :major' do
       let(:target) { :major }
@@ -167,36 +167,36 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: nil (defaults to :rc)' do
       let(:target) { nil }
-      it { should eq '1.1.1.rc.2' }
+      it { should eq '1.1.1-rc.2' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.1.1.rc.2' }
+      it { should eq '1.1.1-rc.2' }
     end
   end
 
   describe 'given 1.0.0.alpha.1' do
-    let(:number) { '1.0.0.alpha.1' }
+    let(:number) { '1.0.0-alpha.1' }
 
     describe 'given target: :alpha' do
       let(:target) { :alpha }
-      it { should eq '1.0.0.alpha.2' }
+      it { should eq '1.0.0-alpha.2' }
     end
 
     describe 'given target: :beta' do
       let(:target) { :beta }
-      it { should eq '1.0.0.beta.1' }
+      it { should eq '1.0.0-beta.1' }
     end
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.0.0.pre.1' }
+      it { should eq '1.0.0-pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.0.0.rc.1' }
+      it { should eq '1.0.0-rc.1' }
     end
   end
 end


### PR DESCRIPTION
This PR changes the version format to comply with Semantic Versioning format, which uses `-` to prerelease versions.
