### PR TITLE
call user_name method instead of git_user_name method 

### DIFF
--- a/lib/gem/release/context/git.rb
+++ b/lib/gem/release/context/git.rb
@@ -26,7 +26,7 @@ module Gem
 
         def user_login
           str = `git config --get github.user`.strip
-          str.empty? ? git_user_name : str
+          str.empty? ? user_name : str
         end
       end
     end


### PR DESCRIPTION
If the user has not configured git with a github user, the following command: 

```
$ gem bootstrap 
```
...yields the following error:

```
Scaffolding gem getsome
ERROR:  While executing gem ... (NameError)
    undefined local variable or method `git_user_name' for #<Gem::Release::Context::Git:0x000055eabe5b5a00>
```

Gem author's intent appears to have been to call the user_name method defined in line 17 above instead of git_user_name, so I changed the code to reflect that intent. Did not test.