### PR TITLE
Fix heredoc for old rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
+# Send builds to container-based infrastructure
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
-dist: trusty
-
-cache: bundler
+language: ruby
+cache:
+  bundler: true
 
 rvm:
+  - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
 
 script: COVERAGE=true bundle exec rspec
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head

--- a/lib/gem/release/cmds/bootstrap.rb
+++ b/lib/gem/release/cmds/bootstrap.rb
@@ -8,7 +8,7 @@ module Gem
       class Bootstrap < Base
         summary 'Scaffolds a new gem from template files.'
 
-        description <<~str
+        description <<-str.split("\n").map(&:lstrip).join("\n")
           #{summary} Optionally initialize a git repository, set a git remote, and push
           to the remote repository.
 

--- a/lib/gem/release/cmds/bump.rb
+++ b/lib/gem/release/cmds/bump.rb
@@ -7,7 +7,7 @@ module Gem
       class Bump < Base
         summary 'Bumps one, several, or all gems in this directory.'
 
-        description <<~str
+        description <<-str.split("\n").map(&:lstrip).join("\n")
           Bumps the version number defined in lib/[gem_name]/version.rb to to a given,
           specific version number, or to the next major, minor, patch, or pre-release
           level.

--- a/lib/gem/release/cmds/gemspec.rb
+++ b/lib/gem/release/cmds/gemspec.rb
@@ -8,7 +8,7 @@ module Gem
       class Gemspec < Base
         summary 'Generates a gemspec.'
 
-        description <<~str
+        description <<-str.split("\n").map(&:lstrip).join("\n")
           #{summary}
 
           If no argument is given the current directory name is used as the gem name. If

--- a/lib/gem/release/cmds/release.rb
+++ b/lib/gem/release/cmds/release.rb
@@ -8,7 +8,7 @@ module Gem
       class Release < Base
         summary 'Releases one or all gems in this directory.'
 
-        description <<~str
+        description <<-str.split("\n").map(&:lstrip).join("\n")
           Builds one or many gems from the given gemspec(s), pushes them to rubygems.org
           (or another, compatible host), and removes the left over gem file.
 

--- a/lib/gem/release/cmds/tag.rb
+++ b/lib/gem/release/cmds/tag.rb
@@ -6,7 +6,7 @@ module Gem
       class Tag < Base
         summary "Tags the HEAD commit with the gem's current version."
 
-        description <<~str
+        description <<-str.split("\n").map(&:lstrip).join("\n")
           Creates an annotated tag for the current HEAD commit, using the gem's
           current version.
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -42,7 +42,7 @@ RSpec::Matchers.define :output do |str|
   end
 
   failure_message do
-    <<~msg
+    <<-msg.split("\n").map(&:lstrip).join("\n")
       Expected stdout to include the string #{str.inspect}, but it does not.\n
       stdout is:\n
       #{out.join("\n")}
@@ -50,7 +50,7 @@ RSpec::Matchers.define :output do |str|
   end
 
   failure_message_when_negated do
-    <<~msg
+    <<-msg.split("\n").map(&:lstrip).join("\n")
       Expected stdout to not include the string #{str.inspect}, but it does.\n
       stdout is:\n
       #{out.join("\n")}
@@ -64,7 +64,7 @@ RSpec::Matchers.define :run_cmd do |cmd|
   end
 
   failure_message do
-    <<~msg
+    <<-msg.split("\n").map(&:lstrip).join("\n")
       Expected the command `#{cmd}` to have run, but it did not.\n
       Run commands are:\n
       #{cmds.join("\n")}
@@ -79,7 +79,7 @@ RSpec::Matchers.define :specify do |name, value|
   end
 
   failure_message do |gemspec|
-    <<~msg
+    <<-msg.split("\n").map(&:lstrip).join("\n")
       Expected this gemspec to specify #{name} as #{value.inspect}, but it did not.\n
       The gemspec is:\n
       #{gemspec}


### PR DESCRIPTION
Replace <<~ (2.3+ only) with <<- plus leading space removing code

Fixes #76