### PR TITLE
Fix bump command to show bumped version for tag & release messages

### DIFF
--- a/lib/gem/release/cmds/bump.rb
+++ b/lib/gem/release/cmds/bump.rb
@@ -136,16 +136,18 @@ module Gem
         }.freeze
 
         def run
+          new_version = nil
           in_gem_dirs do
             validate
             checkout if opts[:branch]
             bump
+            new_version = version.to
             commit if opts[:commit]
             push   if opts[:commit] && opts[:push]
             reset
           end
-          tag     if opts[:tag]
-          release if opts[:release]
+          tag(new_version)     if opts[:tag]
+          release(new_version) if opts[:release]
         end
 
         private
@@ -176,12 +178,12 @@ module Gem
             cmd :git_push, remote
           end
 
-          def tag
-            Tag.new(context, args, opts).run
+          def tag(new_version)
+            Tag.new(context, args, opts.merge(version: new_version)).run
           end
 
-          def release
-            Release.new(context, args, except(opts, :tag)).run
+          def release(new_version)
+            Release.new(context, args, except(opts, :tag).merge(version: new_version)).run
           end
 
           def branch

--- a/lib/gem/release/cmds/release.rb
+++ b/lib/gem/release/cmds/release.rb
@@ -83,7 +83,7 @@ module Gem
           end
 
           def release
-            announce :release, gem.name, gem.version
+            announce :release, gem.name, target_version
             build
             push
           ensure
@@ -110,6 +110,10 @@ module Gem
 
           def cleanup
             cmd :cleanup, gem.filename
+          end
+
+          def target_version
+            opts[:version] || gem.version
           end
       end
     end

--- a/lib/gem/release/cmds/tag.rb
+++ b/lib/gem/release/cmds/tag.rb
@@ -63,7 +63,7 @@ module Gem
 
         def run
           in_gem_dirs do
-            announce :tag, gem.name, gem.version
+            announce :tag, gem.name, target_version
             validate
             tag_and_push
           end
@@ -95,7 +95,7 @@ module Gem
           end
 
           def tag_name
-            "v#{gem.version}"
+            "v#{target_version}"
           end
 
           def push?
@@ -104,6 +104,10 @@ module Gem
 
           def remote
             opts[:remote]
+          end
+
+          def target_version
+            opts[:version] || gem.version
           end
       end
     end


### PR DESCRIPTION
#79 related but incomplete fix

After patch:
![image](https://user-images.githubusercontent.com/1018543/60157318-0f53be80-9821-11e9-9c55-72a0587d0315.png)
Before patch:
![image](https://user-images.githubusercontent.com/1018543/60157345-1c70ad80-9821-11e9-830c-3a1c1e438489.png)

To use correct file name for built gem in `pretend` mode (it's already correct in actual run)
A big change seems to be required since the file name is read through:
- https://github.com/svenfuchs/gem-release/blob/master/lib/gem/release/cmds/release.rb#L98
- https://github.com/svenfuchs/gem-release/blob/master/lib/gem/release/context/gem.rb#L19
- https://github.com/svenfuchs/gem-release/blob/master/lib/gem/release/context/gemspec.rb#L21

And the scale of change required to fix a small pretend mode only issue seems too large for me
Also the filename doesn't matter anyway (Let me know if I am wrong)
If you have better idea let me know (or just submit a PR)
