### PR TITLE
* Make default "stage delimiter" to be dot instead of dash

### DIFF
--- a/lib/gem/release/version/number.rb
+++ b/lib/gem/release/version/number.rb
@@ -45,7 +45,10 @@ module Gem
           end
 
           def stage_delim
-            parts[3] || '-'
+            # Use what's being used or default to dot (`.`)
+            # dot is preferred due to rubygems issue
+            # https://github.com/rubygems/rubygems/issues/592
+            parts[3] || '.'
           end
 
           def num

--- a/spec/gem/release/cmds/bump_spec.rb
+++ b/spec/gem/release/cmds/bump_spec.rb
@@ -84,7 +84,7 @@ describe Gem::Release::Cmds::Bump do
 
     describe 'pre' do
       let(:opts) { { version: :pre } }
-      it { should have_version 'foo/bar', '1.1.0-pre.1' }
+      it { should have_version 'foo/bar', '1.1.0.pre.1' }
     end
   end
 

--- a/spec/gem/release/version/number_spec.rb
+++ b/spec/gem/release/version/number_spec.rb
@@ -31,12 +31,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.1.0-pre.1' }
+      it { should eq '1.1.0.pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.1.0-rc.1' }
+      it { should eq '1.1.0.rc.1' }
     end
   end
 
@@ -65,12 +65,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.2.0-pre.1' }
+      it { should eq '1.2.0.pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.2.0-rc.1' }
+      it { should eq '1.2.0.rc.1' }
     end
   end
 
@@ -99,12 +99,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.2.0-pre.1' }
+      it { should eq '1.2.0.pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.2.0-rc.1' }
+      it { should eq '1.2.0.rc.1' }
     end
   end
 
@@ -333,12 +333,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.1.0-pre.1' }
+      it { should eq '1.1.0.pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.1.0-rc.1' }
+      it { should eq '1.1.0.rc.1' }
     end
   end
 
@@ -372,12 +372,12 @@ describe Gem::Release::Version::Number do
 
     describe 'given target: :pre' do
       let(:target) { :pre }
-      it { should eq '1.1.0-pre.1' }
+      it { should eq '1.1.0.pre.1' }
     end
 
     describe 'given target: :rc' do
       let(:target) { :rc }
-      it { should eq '1.1.0-rc.1' }
+      it { should eq '1.1.0.rc.1' }
     end
   end
 


### PR DESCRIPTION
This is to deal with an issue in rubygems
https://github.com/rubygems/rubygems/issues/592

Reported in https://github.com/svenfuchs/gem-release/issues/86

Fixes #86