### PR TITLE
Ensure git index is refreshed before clean? check

### DIFF
--- a/lib/gem/release/context/git.rb
+++ b/lib/gem/release/context/git.rb
@@ -3,7 +3,7 @@ module Gem
     class Context
       class Git
         def clean?
-          system 'git diff-index --quiet HEAD'
+          system 'git update-index --refresh && git diff-index --quiet HEAD'
         end
 
         def remotes

--- a/lib/gem/release/context/git.rb
+++ b/lib/gem/release/context/git.rb
@@ -3,7 +3,7 @@ module Gem
     class Context
       class Git
         def clean?
-          system 'git update-index --refresh && git diff-index --quiet HEAD'
+          system 'git update-index -q --really-refresh && git diff-index --quiet HEAD'
         end
 
         def remotes


### PR DESCRIPTION
Hi,

I've encountered a problem with `gem bump` telling me that `Uncommitted changes found. Please commit or stash. Aborting.` in cases where I didn't have any uncommitted changes (and `git status` or `git diff` would agree with me on that ;)).

After doing some investigation I discovered that the underlying reason is a combination of a few things:
1. I run my local gem development inside a docker container, with the entire gem working directory mapped as a volume inside the container
1. `git diff-index` is lazy by default, i.e. it considers files to be different when the modification time differs (even when the actual content doesn't)
1. The timezone inside of my docker container is different than my host timezone

As a result, `git diff-index` run inside of my docker container considers all files to be modified, which stops `gem bump` from doing its thing.

I found this `git update-index --refresh` command as a suggested solution to very similar problems described in 
- http://git.661346.n2.nabble.com/BUG-in-git-diff-index-td7652105.html 
- https://stackoverflow.com/questions/34807971/why-does-git-diff-index-head-result-change-for-touched-files-after-git-diff-or-g

Thanks!