### PR TITLE
Fix README generation script

### DIFF
--- a/gem-release.gemspec
+++ b/gem-release.gemspec
@@ -16,6 +16,4 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('{bin/*,lib/**/*,[A-Z]*}', File::FNM_DOTMATCH)
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
-
-  s.add_dependency 'uri'
 end

--- a/script/generate_readme
+++ b/script/generate_readme
@@ -2,12 +2,10 @@
 
 $: << 'lib'
 
-require 'bundler'
+require 'bundler/setup'
 require 'erb'
 require 'stringio'
 load './lib/rubygems_plugin.rb'
-
-Bundler.setup
 
 def camelize(str)
   str.to_s.split(/[^a-z0-9]/i).map { |str| str.capitalize }.join


### PR DESCRIPTION
<!--

Notice: `README.md` is indented to be generated from `README.md.erb` and gem command text in code.
If you intend to update `README.md`, please update `README.md.erb` and/or gem command text in code and optionally run `script/generate_readme` (will be run by GitHub Action if not).

-->

Failing since updated to ruby 3.3
https://github.com/svenfuchs/gem-release/actions/workflows/readme.yaml
