### PR TITLE
Fix error seen when this gem installed but not specified as dependency in project

### DIFF
--- a/gem-release.gemspec
+++ b/gem-release.gemspec
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
-$:.unshift File.expand_path('../lib', __FILE__)
-require 'gem/release/version'
+require_relative 'lib/gem/release/version'
 
 Gem::Specification.new do |s|
   s.name         = 'gem-release'

--- a/lib/gem/release.rb
+++ b/lib/gem/release.rb
@@ -15,5 +15,5 @@ module Gem
   end
 end
 
-require 'gem/release/cmds'
-require 'gem/release/config'
+require_relative 'release/cmds'
+require_relative 'release/config'

--- a/lib/gem/release/cmds.rb
+++ b/lib/gem/release/cmds.rb
@@ -1,10 +1,10 @@
-require 'gem/release/cmds/bootstrap'
-require 'gem/release/cmds/bump'
-require 'gem/release/cmds/gemspec'
-require 'gem/release/cmds/github'
-require 'gem/release/cmds/release'
-require 'gem/release/cmds/runner'
-require 'gem/release/cmds/tag'
+require_relative 'cmds/bootstrap'
+require_relative 'cmds/bump'
+require_relative 'cmds/gemspec'
+require_relative 'cmds/github'
+require_relative 'cmds/release'
+require_relative 'cmds/runner'
+require_relative 'cmds/tag'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/base.rb
+++ b/lib/gem/release/cmds/base.rb
@@ -1,7 +1,7 @@
-require 'gem/release/helper'
-require 'gem/release/helper/hash'
-require 'gem/release/helper/string'
-require 'gem/release/support/registry'
+require_relative '../helper'
+require_relative '../helper/hash'
+require_relative '../helper/string'
+require_relative '../support/registry'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/bootstrap.rb
+++ b/lib/gem/release/cmds/bootstrap.rb
@@ -1,6 +1,6 @@
-require 'gem/release/cmds/base'
-require 'gem/release/data'
-require 'gem/release/files/templates'
+require_relative 'base'
+require_relative '../data'
+require_relative '../files/templates'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/bump.rb
+++ b/lib/gem/release/cmds/bump.rb
@@ -1,5 +1,5 @@
-require 'gem/release/cmds/base'
-require 'gem/release/files/version'
+require_relative 'base'
+require_relative '../files/version'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/gemspec.rb
+++ b/lib/gem/release/cmds/gemspec.rb
@@ -1,6 +1,6 @@
-require 'gem/release/cmds/base'
-require 'gem/release/data'
-require 'gem/release/files/template'
+require_relative 'base'
+require_relative '../data'
+require_relative '../files/template'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/github.rb
+++ b/lib/gem/release/cmds/github.rb
@@ -1,5 +1,5 @@
-require 'gem/release/cmds/base'
-require 'gem/release/context/github'
+require_relative 'base'
+require_relative '../context/github'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/release.rb
+++ b/lib/gem/release/cmds/release.rb
@@ -1,4 +1,4 @@
-require 'gem/release/cmds/base'
+require_relative 'base'
 require 'rubygems/commands/build_command'
 require 'rubygems/commands/push_command'
 

--- a/lib/gem/release/cmds/runner.rb
+++ b/lib/gem/release/cmds/runner.rb
@@ -1,4 +1,4 @@
-require 'gem/release/context'
+require_relative '../context'
 
 module Gem
   module Release

--- a/lib/gem/release/cmds/tag.rb
+++ b/lib/gem/release/cmds/tag.rb
@@ -1,4 +1,4 @@
-require 'gem/release/cmds/base'
+require_relative 'base'
 
 module Gem
   module Release

--- a/lib/gem/release/config.rb
+++ b/lib/gem/release/config.rb
@@ -1,6 +1,6 @@
-require 'gem/release/config/env'
-require 'gem/release/config/files'
-require 'gem/release/helper/hash'
+require_relative 'config/env'
+require_relative 'config/files'
+require_relative 'helper/hash'
 
 module Gem
   module Release

--- a/lib/gem/release/config/env.rb
+++ b/lib/gem/release/config/env.rb
@@ -1,4 +1,4 @@
-require 'gem/release/helper/hash'
+require_relative '../helper/hash'
 
 module Gem
   module Release

--- a/lib/gem/release/config/files.rb
+++ b/lib/gem/release/config/files.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-require 'gem/release/helper/hash'
+require_relative '../helper/hash'
 
 module Gem
   module Release

--- a/lib/gem/release/context.rb
+++ b/lib/gem/release/context.rb
@@ -1,7 +1,7 @@
-require 'gem/release/context/gem'
-require 'gem/release/context/git'
-require 'gem/release/context/paths'
-require 'gem/release/context/ui'
+require_relative 'context/gem'
+require_relative 'context/git'
+require_relative 'context/paths'
+require_relative 'context/ui'
 
 module Gem
   module Release

--- a/lib/gem/release/context/gem.rb
+++ b/lib/gem/release/context/gem.rb
@@ -1,4 +1,4 @@
-require 'gem/release/context/gemspec'
+require_relative 'gemspec'
 
 module Gem
   module Release

--- a/lib/gem/release/context/github.rb
+++ b/lib/gem/release/context/github.rb
@@ -1,6 +1,6 @@
 require 'json'
-require 'gem/release/helper/http'
-require 'gem/release/version'
+require_relative '../helper/http'
+require_relative '../version'
 
 module Gem
   module Release

--- a/lib/gem/release/data.rb
+++ b/lib/gem/release/data.rb
@@ -1,6 +1,6 @@
 require 'erb'
 require 'ostruct'
-require 'gem/release/helper/string'
+require_relative 'helper/string'
 
 module Gem
   module Release

--- a/lib/gem/release/files/template.rb
+++ b/lib/gem/release/files/template.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
-require 'gem/release/files/template/context'
+require_relative 'template/context'
 
 module Gem
   module Release

--- a/lib/gem/release/files/templates.rb
+++ b/lib/gem/release/files/templates.rb
@@ -72,4 +72,4 @@ module Gem
   end
 end
 
-require 'gem/release/files/templates/group'
+require_relative 'templates/group'

--- a/lib/gem/release/files/version.rb
+++ b/lib/gem/release/files/version.rb
@@ -1,4 +1,4 @@
-require 'gem/release/version/number'
+require_relative '../version/number'
 
 module Gem
   module Release

--- a/lib/gem/release/support/gem_command.rb
+++ b/lib/gem/release/support/gem_command.rb
@@ -1,4 +1,4 @@
-require 'gem/release/cmds/runner'
+require_relative '../cmds/runner'
 
 module Gem
   module Release

--- a/lib/rubygems/commands/bootstrap_command.rb
+++ b/lib/rubygems/commands/bootstrap_command.rb
@@ -1,5 +1,5 @@
-require 'gem/release/support/gem_command'
-require 'gem/release/cmds/bootstrap'
+require_relative '../../gem/release/support/gem_command'
+require_relative '../../gem/release/cmds/bootstrap'
 
 class Gem::Commands::BootstrapCommand < Gem::Command
   include Gem::Release::GemCommand

--- a/lib/rubygems/commands/bump_command.rb
+++ b/lib/rubygems/commands/bump_command.rb
@@ -1,5 +1,5 @@
-require 'gem/release/support/gem_command'
-require 'gem/release/cmds/bump'
+require_relative '../../gem/release/support/gem_command'
+require_relative '../../gem/release/cmds/bump'
 
 class Gem::Commands::BumpCommand < Gem::Command
   include Gem::Release::GemCommand

--- a/lib/rubygems/commands/gemspec_command.rb
+++ b/lib/rubygems/commands/gemspec_command.rb
@@ -1,5 +1,5 @@
-require 'gem/release/support/gem_command'
-require 'gem/release/cmds/gemspec'
+require_relative '../../gem/release/support/gem_command'
+require_relative '../../gem/release/cmds/gemspec'
 
 class Gem::Commands::GemspecCommand < Gem::Command
   include Gem::Release::GemCommand

--- a/lib/rubygems/commands/release_command.rb
+++ b/lib/rubygems/commands/release_command.rb
@@ -1,5 +1,5 @@
-require 'gem/release/support/gem_command'
-require 'gem/release/cmds/release'
+require_relative '../../gem/release/support/gem_command'
+require_relative '../../gem/release/cmds/release'
 
 class Gem::Commands::ReleaseCommand < Gem::Command
   include Gem::Release::GemCommand

--- a/lib/rubygems/commands/tag_command.rb
+++ b/lib/rubygems/commands/tag_command.rb
@@ -1,5 +1,5 @@
-require 'gem/release/support/gem_command'
-require 'gem/release/cmds/tag'
+require_relative '../../gem/release/support/gem_command'
+require_relative '../../gem/release/cmds/tag'
 
 class Gem::Commands::TagCommand < Gem::Command
   include Gem::Release::GemCommand

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,14 +1,18 @@
-require 'gem/release'
-require 'rubygems/command_manager'
+begin
+  require 'gem/release'
+  require 'rubygems/command_manager'
 
-require 'rubygems/commands/bootstrap_command'
-require 'rubygems/commands/bump_command'
-require 'rubygems/commands/gemspec_command'
-require 'rubygems/commands/release_command'
-require 'rubygems/commands/tag_command'
+  require 'rubygems/commands/bootstrap_command'
+  require 'rubygems/commands/bump_command'
+  require 'rubygems/commands/gemspec_command'
+  require 'rubygems/commands/release_command'
+  require 'rubygems/commands/tag_command'
 
-Gem::CommandManager.instance.register_command :bootstrap
-Gem::CommandManager.instance.register_command :bump
-Gem::CommandManager.instance.register_command :gemspec
-Gem::CommandManager.instance.register_command :release
-Gem::CommandManager.instance.register_command :tag
+  Gem::CommandManager.instance.register_command :bootstrap
+  Gem::CommandManager.instance.register_command :bump
+  Gem::CommandManager.instance.register_command :gemspec
+  Gem::CommandManager.instance.register_command :release
+  Gem::CommandManager.instance.register_command :tag
+rescue LoadError
+  # Plugin is sometimes run even on projects without this gem specified as dependency
+end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,18 +1,14 @@
-begin
-  require 'gem/release'
-  require 'rubygems/command_manager'
+require_relative 'gem/release'
+require 'rubygems/command_manager'
 
-  require 'rubygems/commands/bootstrap_command'
-  require 'rubygems/commands/bump_command'
-  require 'rubygems/commands/gemspec_command'
-  require 'rubygems/commands/release_command'
-  require 'rubygems/commands/tag_command'
+require_relative 'rubygems/commands/bootstrap_command'
+require_relative 'rubygems/commands/bump_command'
+require_relative 'rubygems/commands/gemspec_command'
+require_relative 'rubygems/commands/release_command'
+require_relative 'rubygems/commands/tag_command'
 
-  Gem::CommandManager.instance.register_command :bootstrap
-  Gem::CommandManager.instance.register_command :bump
-  Gem::CommandManager.instance.register_command :gemspec
-  Gem::CommandManager.instance.register_command :release
-  Gem::CommandManager.instance.register_command :tag
-rescue LoadError
-  # Plugin is sometimes run even on projects without this gem specified as dependency
-end
+Gem::CommandManager.instance.register_command :bootstrap
+Gem::CommandManager.instance.register_command :bump
+Gem::CommandManager.instance.register_command :gemspec
+Gem::CommandManager.instance.register_command :release
+Gem::CommandManager.instance.register_command :tag


### PR DESCRIPTION
Related issues
- https://github.com/rubygems/rubygems/issues/5289

To test:
- `gem uninstall gem-release`
- `gem install gem-release -v '2.2.3.alpha4'`

Update 1: Instead of rescuing `LoadError`, use `require_relative` as suggested in https://github.com/svenfuchs/gem-release/pull/111#pullrequestreview-2512865486