### PR TITLE
Use $XDG_CONFIG_HOME to load config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .env
 coverage
 tmp
+/vendor/

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ gem install gem-release
 # Configuration
 
 Defaults for all options can be specified in a config file at either one of
-these locations:
+these locations in this specific order:
 
-* `~/.gem_release/config.yml`
-* `~/.gem_release.yml`
-* `$XDG_CONFIG_HOME/.gem_release/config.yml`
-* `$XDG_CONFIG_HOME/.gem_release.yml`
-* `./.gem_release/config.yml`
-* `./.gem_release.yml`
+* ./.gem_release/config.yml
+* ./.gem_release.yml
+* $XDG_CONFIG_HOME/.gem_release/config.yml
+* $XDG_CONFIG_HOME/.gem_release.yml
+* ~/.gem_release/config.yml
+* ~/.gem_release.yml
 
 `$XDG_CONFIG_HOME` defaults to `~/.config` if not set.
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ these locations:
 
 * `~/.gem_release/config.yml`
 * `~/.gem_release.yml`
+* `$XDG_CONFIG_HOME/.gem_release/config.yml`
+* `$XDG_CONFIG_HOME/.gem_release.yml`
 * `./.gem_release/config.yml`
 * `./.gem_release.yml`
+
+`$XDG_CONFIG_HOME` defaults to `~/.config` if not set.
 
 Config files must be in the [YAML](http://www.yaml.org/) format, and list
 options per command. Common options can be set on the root.

--- a/README.md.erb
+++ b/README.md.erb
@@ -45,6 +45,7 @@ gem install gem-release
 Defaults for all options can be specified in a config file at either one of
 these locations in this specific order:
 
+<% class Gem::Release::Config::Files; def xdg_config_home; '$XDG_CONFIG_HOME/'; end; end -%>
 <% Gem::Release::Config::Files.new.combine_paths.map do |path| -%>
 * <%= path %>
 <% end %>

--- a/README.md.erb
+++ b/README.md.erb
@@ -47,8 +47,12 @@ these locations:
 
 * `~/.gem_release/config.yml`
 * `~/.gem_release.yml`
+* `$XDG_CONFIG_HOME/.gem_release/config.yml`
+* `$XDG_CONFIG_HOME/.gem_release.yml`
 * `./.gem_release/config.yml`
 * `./.gem_release.yml`
+
+`$XDG_CONFIG_HOME` defaults to `~/.config` if not set.
 
 Config files must be in the [YAML](http://www.yaml.org/) format, and list
 options per command. Common options can be set on the root.

--- a/README.md.erb
+++ b/README.md.erb
@@ -43,15 +43,11 @@ gem install gem-release
 # Configuration
 
 Defaults for all options can be specified in a config file at either one of
-these locations:
+these locations in this specific order:
 
-* `~/.gem_release/config.yml`
-* `~/.gem_release.yml`
-* `$XDG_CONFIG_HOME/.gem_release/config.yml`
-* `$XDG_CONFIG_HOME/.gem_release.yml`
-* `./.gem_release/config.yml`
-* `./.gem_release.yml`
-
+<% Gem::Release::Config::Files.new.combine_paths.map do |path| -%>
+* <%= path %>
+<% end %>
 `$XDG_CONFIG_HOME` defaults to `~/.config` if not set.
 
 Config files must be in the [YAML](http://www.yaml.org/) format, and list

--- a/lib/gem/release/config/files.rb
+++ b/lib/gem/release/config/files.rb
@@ -14,6 +14,14 @@ module Gem
           symbolize_keys(YAML.load_file(path) || {})
         end
 
+        def combine_paths
+          folders = ['./', xdg_config_home, '~/']
+
+          folders.product(FILES).map do |folder, file|
+            File.join(folder, file)
+          end
+        end
+
         private
 
           def path
@@ -28,14 +36,6 @@ module Gem
           def xdg_config_home
             home_config =  File.join(ENV.fetch('HOME'), '.config')
             ENV.fetch('XDG_CONFIG_HOME', home_config)
-          end
-
-          def combine_paths
-            folders = ['./', xdg_config_home, '~/']
-
-            folders.product(FILES).map do |folder, file|
-              File.join(folder, file)
-            end
           end
       end
     end

--- a/lib/gem/release/config/files.rb
+++ b/lib/gem/release/config/files.rb
@@ -7,12 +7,8 @@ module Gem
       class Files
         include Helper::Hash
 
-        PATHS = %w(
-          ./.gem_release/config.yml
-          ./.gem_release.yml
-          ~/.gem_release/config.yml
-          ~/.gem_release.yml
-        )
+        FOLDERS = %w[./ ~/]
+        FILES = %w[.gem_release/config.yml .gem_release.yml]
 
         def load
           return {} unless path
@@ -26,8 +22,14 @@ module Gem
           end
 
           def paths
-            paths = PATHS.map { |path| File.expand_path(path) }
+            paths = combine_paths.map { |path| File.expand_path(path) }
             paths.select { |path| File.exist?(path) }
+          end
+
+          def combine_paths
+            FOLDERS.product(FILES).map do |folder, file|
+              File.join(folder, file)
+            end
           end
       end
     end

--- a/lib/gem/release/config/files.rb
+++ b/lib/gem/release/config/files.rb
@@ -7,7 +7,6 @@ module Gem
       class Files
         include Helper::Hash
 
-        FOLDERS = %w[./ ~/]
         FILES = %w[.gem_release/config.yml .gem_release.yml]
 
         def load
@@ -26,8 +25,15 @@ module Gem
             paths.select { |path| File.exist?(path) }
           end
 
+          def xdg_config_home
+            home_config =  File.join(ENV.fetch('HOME'), '.config')
+            ENV.fetch('XDG_CONFIG_HOME', home_config)
+          end
+
           def combine_paths
-            FOLDERS.product(FILES).map do |folder, file|
+            folders = ['./', xdg_config_home, '~/']
+
+            folders.product(FILES).map do |folder, file|
               File.join(folder, file)
             end
           end

--- a/spec/gem/release/config_spec.rb
+++ b/spec/gem/release/config_spec.rb
@@ -1,6 +1,7 @@
 describe Gem::Release::Config do
   let(:global) { { bump: { commit: false }, tag: { push: false }, quiet: true } }
   let(:local)  { { bump: { commit: true, push: true }, quiet: false } }
+  let(:xdg_config)    { { quiet: true, release: { host: 'https://example.com' } } }
 
   subject { described_class.new.opts }
 
@@ -36,6 +37,41 @@ describe Gem::Release::Config do
     describe 'with an empty file' do
       before { write './.gem_release.yml', '' }
       it { should eq({}) }
+    end
+
+    describe 'XDG_CONFIG_HOME' do
+      describe 'default' do
+        before { write File.join(ENV.fetch('HOME'), '.config/.gem_release.yml'), YAML.dump(xdg_config) }
+        it { should eq xdg_config }
+      end
+
+      describe 'set to /conf' do
+        env XDG_CONFIG_HOME: '/conf'
+        before { write '/conf/.gem_release.yml', YAML.dump(xdg_config) }
+        it { should eq xdg_config }
+      end
+    end
+
+    describe 'all three ./.gem_release.yml, XDG_CONFIG_HOME and ~/.gem_release.yml' do
+      before { write './.gem_release.yml', YAML.dump(local) }
+      env XDG_CONFIG_HOME: '/conf'
+      before { write '/conf/.gem_release.yml', YAML.dump(xdg_config) }
+      before { write '~/.gem_release.yml', YAML.dump(global) }
+      it { should eq local }
+    end
+
+    describe 'both XDG_CONFIG_HOME and ~/.gem_release.yml' do
+      describe 'XDG_CONFIG_HOME default' do
+        before { write File.join(ENV.fetch('HOME'), '.config/.gem_release.yml'), YAML.dump(xdg_config) }
+        before { write '~/.gem_release.yml', YAML.dump(global) }
+        it { should eq xdg_config }
+      end
+      describe 'XDG_CONFIG_HOME set to /conf' do
+        env XDG_CONFIG_HOME: '/conf'
+        before { write '/conf/.gem_release.yml', YAML.dump(xdg_config) }
+        before { write '~/.gem_release.yml', YAML.dump(global) }
+        it { should eq xdg_config }
+      end
     end
   end
 

--- a/spec/gem/release/config_spec.rb
+++ b/spec/gem/release/config_spec.rb
@@ -45,17 +45,17 @@ describe Gem::Release::Config do
         it { should eq xdg_config }
       end
 
-      describe 'set to /conf' do
-        env XDG_CONFIG_HOME: '/conf'
-        before { write '/conf/.gem_release.yml', YAML.dump(xdg_config) }
+      describe 'set to ~/.my-little-config' do
+        env XDG_CONFIG_HOME: '~/.my-little-config'
+        before { write '~/.my-little-config/.gem_release.yml', YAML.dump(xdg_config) }
         it { should eq xdg_config }
       end
     end
 
-    describe 'all three ./.gem_release.yml, XDG_CONFIG_HOME and ~/.gem_release.yml' do
+    describe 'all three ./.gem_release.yml, XDG_CONFIG_HOME, and ~/.gem_release.yml' do
       before { write './.gem_release.yml', YAML.dump(local) }
-      env XDG_CONFIG_HOME: '/conf'
-      before { write '/conf/.gem_release.yml', YAML.dump(xdg_config) }
+      env XDG_CONFIG_HOME: '~/.my-little-config'
+      before { write '~/.my-little-config/.gem_release.yml', YAML.dump(xdg_config) }
       before { write '~/.gem_release.yml', YAML.dump(global) }
       it { should eq local }
     end
@@ -66,9 +66,9 @@ describe Gem::Release::Config do
         before { write '~/.gem_release.yml', YAML.dump(global) }
         it { should eq xdg_config }
       end
-      describe 'XDG_CONFIG_HOME set to /conf' do
-        env XDG_CONFIG_HOME: '/conf'
-        before { write '/conf/.gem_release.yml', YAML.dump(xdg_config) }
+      describe 'XDG_CONFIG_HOME set to ~/.my-little-config' do
+        env XDG_CONFIG_HOME: '~/.my-little-config'
+        before { write '~/.my-little-config/.gem_release.yml', YAML.dump(xdg_config) }
         before { write '~/.gem_release.yml', YAML.dump(global) }
         it { should eq xdg_config }
       end

--- a/spec/gem/release/config_spec.rb
+++ b/spec/gem/release/config_spec.rb
@@ -1,7 +1,7 @@
 describe Gem::Release::Config do
-  let(:global) { { bump: { commit: false }, tag: { push: false }, quiet: true } }
-  let(:local)  { { bump: { commit: true, push: true }, quiet: false } }
-  let(:xdg_config)    { { quiet: true, release: { host: 'https://example.com' } } }
+  let(:global) { { release: { host: 'https://example.com/global' } } }
+  let(:local) { { release: { host: 'https://example.com/local' } } }
+  let(:xdg_config) { { release: { host: 'https://example.com/xdg' } } }
 
   subject { described_class.new.opts }
 


### PR DESCRIPTION
`Config::Files` was only using hardcoded paths from a constant `PATHS`. 
[XDG Base Directory](https://wiki.archlinux.org/title/XDG_Base_Directory) standard suggests that user-specific configuration should be written to $XDG_CONFIG_HOME.
Use `$XDG_CONFIG_HOME`, so that user can store files where they prefer (under version control etc.).